### PR TITLE
fixed issue where the Time library wouldn't compile

### DIFF
--- a/C++/libs/Time/src/Time.cpp
+++ b/C++/libs/Time/src/Time.cpp
@@ -26,8 +26,8 @@ const std::string getCurrentTime (void)
 
   constexpr int dateSize = 26;
   char format[] = "%c";
-  std::string timestamp{dateSize};
-  std::strftime(timestamp.data(), dateSize, format, &localNow);
+  char timestamp[dateSize];
+  std::strftime(timestamp, dateSize, format, &localNow);
   return removeTrailingNewline (timestamp);
 }
 


### PR DESCRIPTION
When attempting to compile the latest main with the recently merged Time library, I ran into this compiler error:

```
src/Time.cpp:30:17: error: cannot initialize a parameter of type 'char *' with an rvalue of type 'const value_type *' (aka 'const char *')
  std::strftime(timestamp.data(), dateSize, format, &localNow);
                ^~~~~~~~~~~~~~~~~
/usr/include/time.h:114:34: note: passing argument to parameter here
size_t strftime(char * __restrict, size_t, const char * __restrict, const struct tm * __restrict) __DARWIN_ALIAS(strftime);
```
I have updated this code section to use a mutable char array instead of a std::string and an accessor method:

```
  char timestamp[dateSize];
  std::strftime(timestamp, dateSize, format, &localNow);
```