### PR TITLE
Fix GCC compile errors. Use a c-style string for strftime

### DIFF
--- a/C++/libs/Time/src/Time.cpp
+++ b/C++/libs/Time/src/Time.cpp
@@ -17,7 +17,7 @@ const std::string getCurrentTime (void)
 {
   std::time_t now = std::chrono::system_clock::to_time_t (std::chrono::system_clock::now ());
   std::tm localNow;
-#ifdef _WIN32
+#if (_MSC_VER > 1300)
   // localtime_s is not in namespace std on vc++ libraries for some reason
   localtime_s(&localNow, &now);
 #else
@@ -26,9 +26,9 @@ const std::string getCurrentTime (void)
 
   constexpr int dateSize = 26;
   char format[] = "%c";
-  std::string timestamp{dateSize};
-  std::strftime(timestamp.data(), dateSize, format, &localNow);
-  return removeTrailingNewline (timestamp);
+  char timestamp[dateSize];
+  std::strftime(timestamp, dateSize, format, &localNow);
+  return removeTrailingNewline (std::string(timestamp));
 }
 
 } // namespace Toolbox::Time


### PR DESCRIPTION
### Changes proposed within this pull request:
- Use MSC_VER macro to determine if we are using Visual Studio, rather than _WIN32
- Pass a temporary character buffer in to std::strftime and then construct a string once it has been populated

Closes #53 