### PR TITLE
Convention cleanup

### DIFF
--- a/C++/Toolbox/Conversion/ConvertibleTo.h
+++ b/C++/Toolbox/Conversion/ConvertibleTo.h
@@ -1,10 +1,9 @@
-#ifndef _CONVERTIBLE_TO_H_
-#define _CONVERTIBLE_TO_H_
-
-namespace Toolbox::Log::Conversion
-{
+#pragma once
 
 #include <Toolbox/Meta/value_type_is.h>
+
+namespace toolbox::conversion
+{
 
 template <typename ... ResultType>
 class ConvertibleTo { };
@@ -13,11 +12,9 @@ template <typename ResultType, typename ... ResultTypes>
 class ConvertibleTo <ResultType, ResultTypes ...> : public ConvertibleTo <ResultTypes ...>
 {
 public:
-  using value_type = type_is_t <ResultType>;
+  using value_type = toolbox::meta::type_is_t <ResultType>;
 
   virtual operator ResultType (void) const = 0;
 };
 
-} // namespace Toolbox::Log::Conversion
-
-#endif // _CONVERTIBLE_TO_H_
+} // namespace toolbox::conversion

--- a/C++/Toolbox/Conversion/Stringifiable.h
+++ b/C++/Toolbox/Conversion/Stringifiable.h
@@ -1,11 +1,9 @@
-#ifndef _STRINGIFIABLE_H_
-#define _STRINGIFIABLE_H_
+#pragma once
 
 #include "ConvertibleTo.h"
-
 #include <string>
 
-namespace Toolbox::Log::Conversion
+namespace toolbox::conversion
 {
 
 class Stringifiable : public ConvertibleTo<std::string>
@@ -15,6 +13,4 @@ public:
   operator std::string (void) const override;
 };
 
-} // namespace Toolbox::Log::Conversion
-
-#endif // _STRINGIFIABLE_H_
+} // namespace toolbox::conversion

--- a/C++/Toolbox/Environment/Development.h
+++ b/C++/Toolbox/Environment/Development.h
@@ -1,7 +1,9 @@
-#ifndef _DEVELOPMENT_H_
-#define _DEVELOPMENT_H_
+#pragma once
 
 #include "Environment.h"
+
+namespace toolbox::environment
+{
 
 class Development : public Environment
 {
@@ -12,4 +14,4 @@ private:
   constexpr static const char * env = "DEVELOPMENT";
 };
 
-#endif // _DEVELOPMENT_H_
+} // namespace toolbox::environment

--- a/C++/Toolbox/Environment/Environment.h
+++ b/C++/Toolbox/Environment/Environment.h
@@ -1,7 +1,9 @@
-#ifndef _ENVIRONMENT_H_
-#define _ENVIRONMENT_H_
+#pragma once
 
 #include <string>
+
+namespace toolbox::environment
+{
 
 class Environment
 {
@@ -9,4 +11,4 @@ public:
   virtual std::string getEnvironment (void) = 0;
 };
 
-#endif // _ENVIRONMENT_H_
+} // namespace toolbox::environment

--- a/C++/Toolbox/Environment/Production.h
+++ b/C++/Toolbox/Environment/Production.h
@@ -1,7 +1,9 @@
-#ifndef _PRODUCTION_H_
-#define _PRODUCTION_H_
+#pragma once
 
 #include "Environment.h"
+
+namespace toolbox::environment
+{
 
 class Production : public Environment
 {
@@ -12,4 +14,4 @@ private:
   constexpr static const char * env = "PRODUCTION";
 };
 
-#endif // _PRODUCTION_H_
+} // namespace toolbox::environment

--- a/C++/Toolbox/Log/Level.h
+++ b/C++/Toolbox/Log/Level.h
@@ -1,9 +1,8 @@
-#ifndef _LEVEL_H_
-#define _LEVEL_H_
+#pragma once
 
 #include <string>
 
-namespace Toolbox::Log
+namespace toolbox::log
 {
 
 enum Level
@@ -18,6 +17,4 @@ enum Level
 
 const std::string levelToString (const Level & level);
 
-} // namespace Toolbox::Log
-
-#endif // _LEVEL_H_
+} // namespace toolbox::log

--- a/C++/Toolbox/Log/Logger.h
+++ b/C++/Toolbox/Log/Logger.h
@@ -1,19 +1,17 @@
-#ifndef _LOGGER_H_
-#define _LOGGER_H_
+#pragma once
 
 #include <Toolbox/Log/Level.h>
 #include <Toolbox/Sink/BasicSink.h>
 #include <Toolbox/Sink/ThreadSafeSink.h>
 #include <Toolbox/Conversion/Stringifiable.h>
-
 #include <memory>
 
-namespace Toolbox::Log
+namespace toolbox::log
 {
 
 class Logger
 {
-using StringSink = Sink::BasicSink<std::string>;
+using StringSink = toolbox::sink::BasicSink<std::string>;
 public:
   explicit Logger (std::unique_ptr<StringSink> sink);
 
@@ -45,6 +43,4 @@ private:
   std::string getCurrentTime (void) const;
 };
 
-} // namespace Toolbox::Log
-
-#endif // _LOGGER_H_
+} // namespace toolbox::log

--- a/C++/Toolbox/Log/Message.h
+++ b/C++/Toolbox/Log/Message.h
@@ -1,13 +1,13 @@
-#ifndef _MESSAGE_H_
-#define _MESSAGE_H_
+#pragma once
 
 #include <Toolbox/Conversion/Stringifiable.h>
-
 #include <string>
 
-namespace Toolbox::Log
+using toolbox::conversion::Stringifiable;
+
+namespace toolbox::log
 {
-using Conversion::Stringifiable;
+
 class Message : public Stringifiable
 {
 public:
@@ -19,6 +19,4 @@ private:
   const std::string _message;
 };
 
-} // namespace Toolbox::Log
-
-#endif // _MESSAGE_H_
+} // namespace toolbox::log

--- a/C++/Toolbox/Meta/inner_type.h
+++ b/C++/Toolbox/Meta/inner_type.h
@@ -1,5 +1,7 @@
-#ifndef _INNER_TYPE_H_
-#define _INNER_TYPE_H_
+#pragma once
+
+namespace toolbox::meta
+{
 
 template <typename T>
 struct inner_type
@@ -22,4 +24,4 @@ struct inner_type <TT <T, Ts ...>>
 template <typename ... Ts>
 using inner_type_t = typename inner_type <Ts ...>::type;
 
-#endif // _INNER_TYPE_H_
+} // namespace toolbox::meta

--- a/C++/Toolbox/Meta/type_is.h
+++ b/C++/Toolbox/Meta/type_is.h
@@ -1,5 +1,7 @@
-#ifndef _TYPE_IS_H_
-#define _TYPE_IS_H_
+#pragma once
+
+namespace toolbox::meta
+{
 
 template <typename T>
 struct type_is
@@ -22,4 +24,4 @@ struct type_is <TT <T, Ts ...>>
 template <typename ... Ts>
 using type_is_t = typename type_is <Ts ...>::type;
 
-#endif // _TYPE_IS_H_
+} // namespace toolbox::meta

--- a/C++/Toolbox/Meta/value_type_is.h
+++ b/C++/Toolbox/Meta/value_type_is.h
@@ -1,7 +1,9 @@
-#ifndef _VALUE_TYPE_IS_H_
-#define _VALUE_TYPE_IS_H_
+#pragma once
 
 #include "type_is.h"
+
+namespace toolbox::meta
+{
 
 template <typename T>
 struct value_type_is
@@ -21,4 +23,4 @@ struct value_type_is <TT <T, Ts ...>>
   using value_type = typename type_is <T>::type;
 };
 
-#endif // _VALUE_TYPE_IS_H_
+} // namespace toolbox::meta

--- a/C++/Toolbox/Option/Option.h
+++ b/C++/Toolbox/Option/Option.h
@@ -5,129 +5,131 @@
 #include <type_traits>
 
 // is_copy_constructible_v alias for older compilers like GCC 6.4
-namespace std {
+namespace std
+{
   template<typename T>
   constexpr bool is_copy_constructible_v = std::is_copy_constructible<T>::value;
+} // namespace std
+
+namespace toolbox::option
+{
+
+/* The fundamental class describing an Option. Users only collect the Opt<T> as a result and do
+   do not instantiate this class directly. The static methods Some, None, and Option have 
+   standalone function aliases for convenience.
+
+   The underlying data structure is a std::unique_ptr. An Opt<T> is move only. 
+
+   The fundamental operations are forEach, map, and filter. `forEach` simply allows access to the
+   underlying data if it is Some. `map` and `filter` allow access and modification of the Opt<T>.
+*/ 
+template<typename T>
+class Opt
+{
+public:
+  // forward arguments to construct a Some<T>
+  template<typename... Args>
+  static Opt Some(Args... args)
+  {
+    return Opt<T>(std::make_unique<T>(std::forward<Args>(args)...));
+  }
+
+  // Create a None<T>
+  static Opt None()
+  {
+    return Opt<T>();
+  }
+
+  // Create an Option from a pointer
+  // None<T> if is nullptr
+  // Else Some<T>
+  static Opt Option(T* t)
+  {
+    return Opt<T>(std::move(std::unique_ptr<T>(t)));
+  }
+
+private:
+  // Hidden constructors - one can't instantiate an Opt directly, only the class can
+  Opt(void) = default;
+  Opt(std::unique_ptr<T> p) : _data(std::move(p)) {};
+
+public:
+  // No copy constructor available, explicitly delete so that it so intent is clear
+  Opt(const Opt&) = delete;
+  Opt(Opt&&) = default;
+
+  // prevent implicit deletion by being explicit
+  Opt& operator=(const Opt& other) = delete;
+  Opt& operator=(Opt&& other) = default;
+
+public:
+  // operator bool for quick check
+  operator bool() const {
+    return (_data != nullptr);
+  };
+
+public:
+  // ifPresent - read the value if it exists
+  void ifPresent(std::function<void(const T&)> ifPresentFunction) {
+    if (_data)
+      ifPresentFunction(*_data.get());
+  };
+
+  // map - concrete for mapping to the same type, saves one from typing the template parameter
+  Opt<T> map(std::function<T(T t)> mapFunction) {
+    return Opt::map<T>(mapFunction);
+  };
+
+  // map<T,U>  - map from an Opt<T> to an Opt<U>
+  // Not available if the type T is not copy constructible
+  // if is None<T>, then returns None<U>
+  // else returns Some<U>
+  template<typename U, typename = typename std::enable_if<std::is_copy_constructible_v<T> == true>::type>
+  Opt<U> map(std::function<U(T)> mapFunction) {
+    static_assert(std::is_copy_constructible_v<U> == true, "Target type must be copy constructible.");
+    if (_data) {
+      auto u = mapFunction(*_data);
+      U* pU = new U(u);
+      return Opt<U>::Option(pU);
+    }
+    else {
+      return Opt<U>::None();
+    }
+  };
+
+  // filter<T> - retains the option based on a predicate. Returns a new option. 
+  Opt<T> filter(std::function<bool(const T&)> filterFunction) {
+    if (_data) {
+      bool retain = filterFunction(*_data);
+      return (retain) ? Opt<T>::Option(new T(*_data)) : Opt<T>::None();
+    }
+    else {
+      return Opt<T>::None();
+    }
+  };
+
+private:
+  // the underlying data as a unique_ptr
+  std::unique_ptr<T> _data;
+
+}; // end of class Opt<T>
+
+// The Some<T> function alias for Opt<T>::Some
+template<typename T, typename... Args>
+Opt<T> Some(Args&&... args) {
+  return Opt<T>::Some(std::forward<Args>(args)...);
 }
 
-namespace Toolbox::Option {
+// The None<T> function alias for Opt<T>::None
+template<typename T>
+Opt<T> None() {
+  return Opt<T>::None();
+}
 
-  /* The fundamental class describing an Option. Users only collect the Opt<T> as a result and do
-     do not instantiate this class directly. The static methods Some, None, and Option have 
-     standalone function aliases for convenience.
+// The Option<T> function alias for Opt<T>::Option
+template<typename T>
+Opt<T> Option(T* t) {
+  return Opt<T>::Option(t);
+}
 
-     The underlying data structure is a std::unique_ptr. An Opt<T> is move only. 
-
-     The fundamental operations are forEach, map, and filter. `forEach` simply allows access to the
-     underlying data if it is Some. `map` and `filter` allow access and modification of the Opt<T>.
-  */ 
-  template<typename T>
-  class Opt
-  {
-  public:
-    // forward arguments to construct a Some<T>
-    template<typename... Args>
-    static Opt Some(Args... args)
-    {
-      return Option::Opt<T>(std::make_unique<T>(std::forward<Args>(args)...));
-    }
-
-    // Create a None<T>
-    static Opt None()
-    {
-      return Option::Opt<T>();
-    }
-
-    // Create an Option from a pointer
-    // None<T> if is nullptr
-    // Else Some<T>
-    static Opt Option(T* t)
-    {
-      return Option::Opt<T>(std::move(std::unique_ptr<T>(t)));
-    }
-
-  private:
-    // Hidden constructors - one can't instantiate an Opt directly, only the class can
-    Opt(void) = default;
-    Opt(std::unique_ptr<T> p) : _pData(std::move(p)) {};
-
-  public:
-    // No copy constructor available, explicitly delete so that it so intent is clear
-    Opt(const Opt&) = delete;
-    Opt(Opt&&) = default;
-
-    // prevent implicit deletion by being explicit
-    Opt& operator=(const Opt& other) = delete;
-    Opt& operator=(Opt&& other) = default;
-
-  public:
-    // operator bool for quick check
-    operator bool() const {
-      return (_pData != nullptr);
-    };
-
-  public:
-    // ifPresent - read the value if it exists
-    void ifPresent(std::function<void(const T&)> ifPresentFunction) {
-      if (_pData)
-        ifPresentFunction(*_pData.get());
-    };
-
-    // map - concrete for mapping to the same type, saves one from typing the template parameter
-    Opt<T> map(std::function<T(T t)> mapFunction) {
-      return Opt::map<T>(mapFunction);
-    };
-
-    // map<T,U>  - map from an Opt<T> to an Opt<U>
-    // Not available if the type T is not copy constructible
-    // if is None<T>, then returns None<U>
-    // else returns Some<U>
-    template<typename U, typename = typename std::enable_if<std::is_copy_constructible_v<T> == true>::type>
-    Opt<U> map(std::function<U(T)> mapFunction) {
-      static_assert(std::is_copy_constructible_v<U> == true, "Target type must be copy constructible.");
-      if (_pData) {
-        auto u = mapFunction(*_pData);
-        U* pU = new U(u);
-        return Opt<U>::Option(pU);
-      }
-      else {
-        return Opt<U>::None();
-      }
-    };
-
-    // filter<T> - retains the option based on a predicate. Returns a new option. 
-    Opt<T> filter(std::function<bool(const T&)> filterFunction) {
-      if (_pData) {
-        bool retain = filterFunction(*_pData);
-        return (retain) ? Opt<T>::Option(new T(*_pData)) : Opt<T>::None();
-      }
-      else {
-        return Opt<T>::None();
-      }
-    };
-
-  private:
-    // the underlying data as a unique_ptr
-    std::unique_ptr<T> _pData;
-
-  }; // end of class Opt<T>
-
-  // The Some<T> function alias for Opt<T>::Some
-  template<typename T, typename... Args>
-  Opt<T> Some(Args&&... args) {
-    return Option::Opt<T>::Some(std::forward<Args>(args)...);
-  }
-
-  // The None<T> function alias for Opt<T>::None
-  template<typename T>
-  Opt<T> None() {
-    return Option::Opt<T>::None();
-  }
- 
-  // The Option<T> function alias for Opt<T>::Option
-  template<typename T>
-  Opt<T> Option(T* t) {
-    return Option::Opt<T>::Option(t);
-  }
-
-} // Toolbox::Option
+} // namespace toolbox::option

--- a/C++/Toolbox/Sink/BasicSink.h
+++ b/C++/Toolbox/Sink/BasicSink.h
@@ -1,9 +1,8 @@
-#ifndef _BASIC_SINK_H_
-#define _BASIC_SINK_H_
+#pragma once
 
 #include <Toolbox/Conversion/ConvertibleTo.h>
 
-namespace Toolbox::Sink
+namespace toolbox::sink
 {
 
 template <typename OutputType>
@@ -33,6 +32,4 @@ protected:
   virtual void output (const OutputType & output) = 0;
 };
 
-} // namespace Toolbox::Sink
-
-#endif // _BASIC_SINK_H_
+} // namespace toolbox::sink

--- a/C++/Toolbox/Sink/ConsoleSink.h
+++ b/C++/Toolbox/Sink/ConsoleSink.h
@@ -1,11 +1,9 @@
-#ifndef _CONSOLE_SINK_H_
-#define _CONSOLE_SINK_H_
+#pragma once
 
 #include <Toolbox/Sink/ThreadSafeSink.h>
-
 #include <string>
 
-namespace Toolbox::Sink
+namespace toolbox::sink
 {
 
 class ConsoleSink : public ThreadSafeSink<std::string>
@@ -14,6 +12,4 @@ public:
   void output (const std::string & output) override;
 };
 
-} // namespace Toolbox::Sink
-
-#endif // _CONSOLE_SINK_H_
+} // namespace toolbox::sink

--- a/C++/Toolbox/Sink/ThreadSafeProxySink.h
+++ b/C++/Toolbox/Sink/ThreadSafeProxySink.h
@@ -1,13 +1,11 @@
-#ifndef _TOOLBOX_SINK_THREAD_SAFE_PROXY_SINK_H_
-#define _TOOLBOX_SINK_THREAD_SAFE_PROXY_SINK_H_
+#pragma once
 
 #include <Toolbox/Sink/BasicSink.h>
 #include <Toolbox/Sink/ThreadSafeSink.h>
-
 #include <memory>
 #include <type_traits>
 
-namespace Toolbox::Sink
+namespace toolbox::sink
 {
 
 template <typename SinkType,
@@ -34,9 +32,9 @@ ThreadSafeProxySink & operator= (ThreadSafeProxySink && sink)
 }
 
 /**
-* Synchronization is performed within the ThreadSafeSink base class's operator << method.
-* Forward the output to the inner Sink.
-*/
+ * Synchronization is performed within the ThreadSafeSink base class's operator << method.
+ * Forward the output to the inner Sink.
+ */
 virtual void output (const OutputType & output) override
 {
   _sink << output;
@@ -64,6 +62,4 @@ auto make_unique_thread_safe (Args&&... args)
   return std::make_unique<ThreadSafeProxySink<SinkType>> (SinkType (std::forward<Args> (args)...));
 }
 
-} // namespace Toolbox::Sink
-
-#endif // _TOOLBOX_SINK_THREAD_SAFE_PROXY_SINK_H_
+} // namespace toolbox::sink

--- a/C++/Toolbox/Sink/ThreadSafeSink.h
+++ b/C++/Toolbox/Sink/ThreadSafeSink.h
@@ -1,11 +1,9 @@
-#ifndef _SYNC_SINK_H_
-#define _SYNC_SINK_H_
+#pragma once
 
 #include <Toolbox/Sink/BasicSink.h>
-
 #include <mutex>
 
-namespace Toolbox::Sink
+namespace toolbox::sink
 {
 
 template <typename OutputType>
@@ -22,6 +20,4 @@ protected:
   mutable std::mutex _mutex;
 };
 
-} // namespace Toolbox::Sink
-
-#endif // _SYNC_SINK_H_
+} // namespace toolbox::sink

--- a/C++/Toolbox/Time/Time.h
+++ b/C++/Toolbox/Time/Time.h
@@ -1,9 +1,9 @@
 #include <string>
 
-namespace Toolbox::Time
+namespace toolbox::time
 {
 
 const std::string getCurrentTime (void);
 
-} // namespace Toolbox::Time
+} // namespace toolbox::time
 

--- a/C++/libs/Conversion/src/Stringifiable.cpp
+++ b/C++/libs/Conversion/src/Stringifiable.cpp
@@ -5,7 +5,7 @@ namespace toolbox::conversion
 
 Stringifiable::operator std::string (void) const
 {
-  return toString ();
+  return toString();
 }
 
 } // namespace toolbox::conversion

--- a/C++/libs/Conversion/src/Stringifiable.cpp
+++ b/C++/libs/Conversion/src/Stringifiable.cpp
@@ -1,6 +1,6 @@
 #include <Toolbox/Conversion/Stringifiable.h>
 
-namespace Toolbox::Log::Conversion
+namespace toolbox::conversion
 {
 
 Stringifiable::operator std::string (void) const
@@ -8,4 +8,4 @@ Stringifiable::operator std::string (void) const
   return toString ();
 }
 
-} // namespace Toolbox::Log::Conversion
+} // namespace toolbox::conversion

--- a/C++/libs/Conversion/test/src/TestMessage.cpp
+++ b/C++/libs/Conversion/test/src/TestMessage.cpp
@@ -4,7 +4,7 @@ namespace toolbox::conversion::test
 {
 
 Message::Message (const std::string & message)
-: _message (message)
+: _message(message)
 {
 
 }

--- a/C++/libs/Conversion/test/src/TestMessage.cpp
+++ b/C++/libs/Conversion/test/src/TestMessage.cpp
@@ -1,17 +1,22 @@
 #include "TestMessage.h"
 
-TestMessage::TestMessage (const std::string & message)
+namespace toolbox::conversion::test
+{
+
+Message::Message (const std::string & message)
 : _message (message)
 {
 
 }
 
-TestMessage::operator std::string (void) const
+Message::operator std::string (void) const
 {
   return _message;
 }
 
-TestMessage::operator size_t (void) const
+Message::operator size_t (void) const
 {
   return _message.length();
 }
+
+} // namespace toolbox::conversion::test

--- a/C++/libs/Conversion/test/src/TestMessage.h
+++ b/C++/libs/Conversion/test/src/TestMessage.h
@@ -1,16 +1,17 @@
-#ifndef _TEST_MESSAGE_H_
-#define _TEST_MESSAGE_H_
+#pragma once
 
 #include <Toolbox/Conversion/ConvertibleTo.h>
-
 #include <string>
 
-using Toolbox::Log::Conversion::ConvertibleTo;
+using toolbox::conversion::ConvertibleTo;
 
-class TestMessage : public ConvertibleTo<std::string, size_t>
+namespace toolbox::conversion::test
+{
+
+class Message : public ConvertibleTo<std::string, size_t>
 {
 public:
-  explicit TestMessage (const std::string & message);
+  explicit Message (const std::string & message);
 
   operator std::string (void) const override;
 
@@ -20,4 +21,4 @@ private:
   const std::string _message;
 };
 
-#endif // _TEST_MESSAGE_H_
+} // namespace toolbox::conversion::test

--- a/C++/libs/Conversion/test/src/TestStringifiable.cpp
+++ b/C++/libs/Conversion/test/src/TestStringifiable.cpp
@@ -1,0 +1,17 @@
+#include "TestStringifiable.h"
+
+namespace toolbox::conversion::test
+{
+
+Stringifiable::Stringifiable (const std::string & message)
+: _message (message)
+{
+
+}
+
+const std::string Stringifiable::toString (void) const
+{
+  return _message;
+}
+
+} // namespace toolbox::conversion::test

--- a/C++/libs/Conversion/test/src/TestStringifiable.cpp
+++ b/C++/libs/Conversion/test/src/TestStringifiable.cpp
@@ -4,7 +4,7 @@ namespace toolbox::conversion::test
 {
 
 Stringifiable::Stringifiable (const std::string & message)
-: _message (message)
+: _message(message)
 {
 
 }

--- a/C++/libs/Conversion/test/src/TestStringifiable.h
+++ b/C++/libs/Conversion/test/src/TestStringifiable.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <Toolbox/Conversion/Stringifiable.h>
+#include <string>
+
+namespace toolbox::conversion::test
+{
+
+class Stringifiable : public toolbox::conversion::Stringifiable
+{
+public:
+  explicit Stringifiable (const std::string & message);
+
+  const std::string toString (void) const override;
+
+private:
+  const std::string _message;
+};
+
+} // namespace toolbox::conversion::test

--- a/C++/libs/Conversion/test/src/Test_ConvertibleTo.cpp
+++ b/C++/libs/Conversion/test/src/Test_ConvertibleTo.cpp
@@ -1,12 +1,12 @@
 #include <Toolbox/catch.hpp>
 #include "TestMessage.h"
 
-#include <string>
+using namespace toolbox::conversion;
 
 TEST_CASE ("Implementation of ConvertibleTo string converts to string")
 {
   const std::string message = "test";
-  TestMessage testMessage (message);
+  test::Message testMessage (message);
   const std::string convertedValue = testMessage;
 
   REQUIRE (message == convertedValue);
@@ -15,8 +15,8 @@ TEST_CASE ("Implementation of ConvertibleTo string converts to string")
 TEST_CASE ("Implementation of ConvertibleTo string converts to size_t")
 {
   const std::string message = "test";
-  TestMessage testMessage (message);
+  test::Message testMessage (message);
   const size_t messageLength = testMessage;
 
-  REQUIRE (message.length() == messageLength);
+  REQUIRE (message.length () == messageLength);
 }

--- a/C++/libs/Conversion/test/src/Test_ConvertibleTo.cpp
+++ b/C++/libs/Conversion/test/src/Test_ConvertibleTo.cpp
@@ -6,17 +6,17 @@ using namespace toolbox::conversion;
 TEST_CASE ("Implementation of ConvertibleTo string converts to string")
 {
   const std::string message = "test";
-  test::Message testMessage (message);
+  test::Message testMessage(message);
   const std::string convertedValue = testMessage;
 
-  REQUIRE (message == convertedValue);
+  REQUIRE(message == convertedValue);
 }
 
 TEST_CASE ("Implementation of ConvertibleTo string converts to size_t")
 {
   const std::string message = "test";
-  test::Message testMessage (message);
+  test::Message testMessage(message);
   const size_t messageLength = testMessage;
 
-  REQUIRE (message.length () == messageLength);
+  REQUIRE(message.length() == messageLength);
 }

--- a/C++/libs/Conversion/test/src/Test_Stringifiable.cpp
+++ b/C++/libs/Conversion/test/src/Test_Stringifiable.cpp
@@ -6,15 +6,15 @@ using namespace toolbox::conversion;
 TEST_CASE ("toString result matches the input")
 {
   const std::string message = "test";
-  test::Stringifiable testStringifiable (message);
-  REQUIRE (testStringifiable.toString () == message);
+  test::Stringifiable testStringifiable(message);
+  REQUIRE(testStringifiable.toString() == message);
 }
 
 TEST_CASE ("toString result matches the converted value")
 {
   const std::string message = "test";
-  test::Stringifiable testStringifiable (message);
+  test::Stringifiable testStringifiable(message);
   const std::string convertedValue = testStringifiable;
 
-  REQUIRE (testStringifiable.toString () == convertedValue);
+  REQUIRE(testStringifiable.toString() == convertedValue);
 }

--- a/C++/libs/Conversion/test/src/Test_Stringifiable.cpp
+++ b/C++/libs/Conversion/test/src/Test_Stringifiable.cpp
@@ -1,33 +1,19 @@
 #include <Toolbox/catch.hpp>
-#include <Toolbox/Conversion/Stringifiable.h>
+#include "TestStringifiable.h"
 
-using Toolbox::Log::Conversion::Stringifiable;
-
-class TestStringifiable : public Stringifiable
-{
-public:
-  explicit TestStringifiable (const std::string & message) : _message (message) {}
-
-  const std::string toString (void) const override
-  {
-    return _message;
-  }
-
-private:
-  const std::string _message;
-};
+using namespace toolbox::conversion;
 
 TEST_CASE ("toString result matches the input")
 {
   const std::string message = "test";
-  TestStringifiable testStringifiable (message);
+  test::Stringifiable testStringifiable (message);
   REQUIRE (testStringifiable.toString () == message);
 }
 
 TEST_CASE ("toString result matches the converted value")
 {
   const std::string message = "test";
-  TestStringifiable testStringifiable (message);
+  test::Stringifiable testStringifiable (message);
   const std::string convertedValue = testStringifiable;
 
   REQUIRE (testStringifiable.toString () == convertedValue);

--- a/C++/libs/Environment/src/Development.cpp
+++ b/C++/libs/Environment/src/Development.cpp
@@ -5,7 +5,7 @@ namespace toolbox::environment
 
 std::string Development::getEnvironment (void)
 {
-  return std::string { env };
+  return std::string{env};
 }
 
 } // namespace toolbox::environment

--- a/C++/libs/Environment/src/Development.cpp
+++ b/C++/libs/Environment/src/Development.cpp
@@ -1,6 +1,11 @@
 #include <Toolbox/Environment/Development.h>
 
+namespace toolbox::environment
+{
+
 std::string Development::getEnvironment (void)
 {
   return std::string { env };
 }
+
+} // namespace toolbox::environment

--- a/C++/libs/Environment/src/Production.cpp
+++ b/C++/libs/Environment/src/Production.cpp
@@ -5,7 +5,7 @@ namespace toolbox::environment
 
 std::string Production::getEnvironment (void)
 {
-  return std::string { env };
+  return std::string{env};
 }
 
 } // namespace toolbox::environment

--- a/C++/libs/Environment/src/Production.cpp
+++ b/C++/libs/Environment/src/Production.cpp
@@ -1,6 +1,11 @@
 #include <Toolbox/Environment/Production.h>
 
+namespace toolbox::environment
+{
+
 std::string Production::getEnvironment (void)
 {
   return std::string { env };
 }
+
+} // namespace toolbox::environment

--- a/C++/libs/Log/src/Level.cpp
+++ b/C++/libs/Log/src/Level.cpp
@@ -1,6 +1,6 @@
 #include <Toolbox/Log/Level.h>
 
-namespace Toolbox::Log
+namespace toolbox::log
 {
 
 const std::string levelToString (const Level & level)
@@ -17,4 +17,4 @@ const std::string levelToString (const Level & level)
   }
 }
 
-} // namespace Toolbox::Log
+} // namespace toolbox::log

--- a/C++/libs/Log/src/Logger.cpp
+++ b/C++/libs/Log/src/Logger.cpp
@@ -1,7 +1,7 @@
 #include <Toolbox/Log/Logger.h>
 #include <Toolbox/Time/Time.h>
 
-namespace Toolbox::Log
+namespace toolbox::log
 {
 
 Logger::Logger (std::unique_ptr<StringSink> sink)
@@ -74,13 +74,13 @@ void Logger::setDefault (const Level & level)
 
 void Logger::logIfAboveThreshold (const Level & level, const std::string & message)
 {
-  if (isAboveThreshold (level))
+  if (_sink && isAboveThreshold (level))
     (*_sink) << createLogMessage (level, message);
 }
 
 bool Logger::isAboveThreshold (const Level & level) const
 {
-  return level >= _threshold;
+  return (level >= _threshold);
 }
 
 std::string Logger::createLogMessage (const Level & level, const std::string & message) const
@@ -90,7 +90,7 @@ std::string Logger::createLogMessage (const Level & level, const std::string & m
 
 std::string Logger::getCurrentTime (void) const
 {
-  return Time::getCurrentTime();
+  return time::getCurrentTime();
 }
 
-} // namespace Toolbox::Log
+} // namespace toolbox::log

--- a/C++/libs/Log/src/Logger.cpp
+++ b/C++/libs/Log/src/Logger.cpp
@@ -5,51 +5,51 @@ namespace toolbox::log
 {
 
 Logger::Logger (std::unique_ptr<StringSink> sink)
-: _default (Level::INFO)
-, _threshold (Level::TRACE)
-, _sink (std::move (sink))
+: _default(Level::INFO)
+, _threshold(Level::TRACE)
+, _sink(std::move(sink))
 {
   
 }
 
 void Logger::log (const std::string & message)
 {
-  logIfAboveThreshold (_default, message);
+  logIfAboveThreshold(_default, message);
 }
 
 void Logger::log (const Level & level, const std::string & message)
 {
-  logIfAboveThreshold (level, message);
+  logIfAboveThreshold(level, message);
 }
 
 void Logger::trace (const std::string & message)
 {
-  logIfAboveThreshold (Level::TRACE, message);
+  logIfAboveThreshold(Level::TRACE, message);
 }
 
 void Logger::debug (const std::string & message)
 {
-  logIfAboveThreshold (Level::DEBUG, message);
+  logIfAboveThreshold(Level::DEBUG, message);
 }
 
 void Logger::info (const std::string & message)
 {
-  logIfAboveThreshold (Level::INFO, message);
+  logIfAboveThreshold(Level::INFO, message);
 }
 
 void Logger::warning (const std::string & message)
 {
-  logIfAboveThreshold (Level::WARNING, message);
+  logIfAboveThreshold(Level::WARNING, message);
 }
 
 void Logger::error (const std::string & message)
 {
-  logIfAboveThreshold (Level::ERROR, message);
+  logIfAboveThreshold(Level::ERROR, message);
 }
 
 void Logger::fatal (const std::string & message)
 {
-  logIfAboveThreshold (Level::FATAL, message);
+  logIfAboveThreshold(Level::FATAL, message);
 }
 
 Level Logger::getThreshold (void) const
@@ -74,8 +74,8 @@ void Logger::setDefault (const Level & level)
 
 void Logger::logIfAboveThreshold (const Level & level, const std::string & message)
 {
-  if (_sink && isAboveThreshold (level))
-    (*_sink) << createLogMessage (level, message);
+  if (_sink && isAboveThreshold(level))
+    (*_sink) << createLogMessage(level, message);
 }
 
 bool Logger::isAboveThreshold (const Level & level) const
@@ -85,7 +85,7 @@ bool Logger::isAboveThreshold (const Level & level) const
 
 std::string Logger::createLogMessage (const Level & level, const std::string & message) const
 {
-  return levelToString (level) + ": " + message + "\n";
+  return levelToString(level) + ": " + message + "\n";
 }
 
 std::string Logger::getCurrentTime (void) const

--- a/C++/libs/Log/src/Message.cpp
+++ b/C++/libs/Log/src/Message.cpp
@@ -4,7 +4,7 @@ namespace toolbox::log
 {
   
 Message::Message (const std::string & message)
-: _message (message)
+: _message(message)
 {
 
 }

--- a/C++/libs/Log/src/Message.cpp
+++ b/C++/libs/Log/src/Message.cpp
@@ -1,6 +1,6 @@
 #include <Toolbox/Log/Message.h>
 
-namespace Toolbox::Log
+namespace toolbox::log
 {
   
 Message::Message (const std::string & message)
@@ -14,4 +14,4 @@ const std::string Message::toString (void) const
   return _message;
 }
 
-} // namespace Toolbox::Log
+} // namespace toolbox::log

--- a/C++/libs/Log/test/src/Level.cpp
+++ b/C++/libs/Log/test/src/Level.cpp
@@ -1,7 +1,7 @@
 #include <Toolbox/catch.hpp>
 #include <Toolbox/Log/Level.h>
 
-using namespace Toolbox::Log;
+using namespace toolbox::log;
 
 TEST_CASE ("levelToString converts a Level to its string representation")
 {

--- a/C++/libs/Log/test/src/Level.cpp
+++ b/C++/libs/Log/test/src/Level.cpp
@@ -5,5 +5,5 @@ using namespace toolbox::log;
 
 TEST_CASE ("levelToString converts a Level to its string representation")
 {
-  REQUIRE (levelToString (Level::INFO) == "INFO");
+  REQUIRE(levelToString(Level::INFO) == "INFO");
 }

--- a/C++/libs/Log/test/src/Logger.cpp
+++ b/C++/libs/Log/test/src/Logger.cpp
@@ -6,7 +6,7 @@
 #include <Toolbox/Log/Level.h>
 #include <Toolbox/Log/Logger.h>
 
-using namespace Toolbox::Log;
+using namespace toolbox::log;
 
 const std::string createMessage (const Level & level, const std::string & message)
 {
@@ -16,7 +16,7 @@ const std::string createMessage (const Level & level, const std::string & messag
 TEST_CASE ("get and set default log level")
 {
   std::string rc;
-  Logger logger (std::make_unique<Test::Sink> (rc));
+  Logger logger (std::make_unique<test::Sink> (rc));
  
   Level level = Level::DEBUG;
   logger.setDefault (level);
@@ -27,7 +27,7 @@ TEST_CASE ("get and set default log level")
 TEST_CASE ("get and set threshold log level")
 {
   std::string rc;
-  Logger logger (std::make_unique<Test::Sink> (rc));
+  Logger logger (std::make_unique<test::Sink> (rc));
   
   Level level = Level::DEBUG;
   logger.setThreshold (level);
@@ -38,7 +38,7 @@ TEST_CASE ("get and set threshold log level")
 TEST_CASE ("log with default level")
 {
   std::string rc;
-  Logger logger (std::make_unique<Test::Sink> (rc));
+  Logger logger (std::make_unique<test::Sink> (rc));
   
   const std::string message = "message";
   logger.log (message);
@@ -49,7 +49,7 @@ TEST_CASE ("log with default level")
 TEST_CASE ("log with specific level")
 {
   std::string rc;
-  Logger logger (std::make_unique<Test::Sink> (rc));
+  Logger logger (std::make_unique<test::Sink> (rc));
   
   const std::string message = "message";
   Level level = Level::INFO;
@@ -61,7 +61,7 @@ TEST_CASE ("log with specific level")
 TEST_CASE ("can log strings")
 {
   std::string rc;
-  Logger logger (std::make_unique<Test::Sink> (rc));
+  Logger logger (std::make_unique<test::Sink> (rc));
 
   const std::string message = "message";
   logger.log (message);
@@ -72,10 +72,10 @@ TEST_CASE ("can log strings")
 TEST_CASE ("can log ConvertibleTo<string> objects")
 {
   std::string rc;
-  Logger logger (std::make_unique<Test::Sink> (rc));
+  Logger logger (std::make_unique<test::Sink> (rc));
 
   const std::string message = "message";
-  const TestMessage testMessage (message);
+  const test::Message testMessage (message);
   logger.log (testMessage);
 
   REQUIRE (rc == createMessage (logger.getDefault (), message));
@@ -84,85 +84,79 @@ TEST_CASE ("can log ConvertibleTo<string> objects")
 TEST_CASE ("logger.trace logs at trace log level")
 {
   std::string rc;
-  Logger logger (std::make_unique<Test::Sink> (rc));
+  Logger logger (std::make_unique<test::Sink> (rc));
  
   const std::string message = "message";
   logger.trace (message);
 
   const std::string level = levelToString (Level::TRACE);
-  std::string result = rc;
-  REQUIRE (result.find (level) != std::string::npos);
+  REQUIRE (rc.find (level) != std::string::npos);
 }
 
 TEST_CASE ("logger.debug logs at debug log level")
 {
   std::string rc;
-  Logger logger (std::make_unique<Test::Sink> (rc));
+  Logger logger (std::make_unique<test::Sink> (rc));
   
   const std::string message = "message";
   logger.debug (message);
 
   const std::string level = levelToString (Level::DEBUG);
-  std::string result = rc;
-  REQUIRE (result.find (level) != std::string::npos);
+  REQUIRE (rc.find (level) != std::string::npos);
 }
 
 TEST_CASE ("logger.info logs at info log level")
 {
   std::string rc;
-  Logger logger (std::make_unique<Test::Sink> (rc));
+  Logger logger (std::make_unique<test::Sink> (rc));
   
   const std::string message = "message";
   logger.info (message);
 
   const std::string level = levelToString (Level::INFO);
-  std::string result = rc;
-  REQUIRE (result.find (level) != std::string::npos);
+  REQUIRE (rc.find (level) != std::string::npos);
 }
 
 TEST_CASE ("logger.warning logs at warning log level")
 {
   std::string rc;
-  Logger logger (std::make_unique<Test::Sink> (rc));
+  Logger logger (std::make_unique<test::Sink> (rc));
   
   const std::string message = "message";
   logger.warning (message);
 
   const std::string level = levelToString (Level::WARNING);
-  std::string result = rc;
-  REQUIRE (result.find (level) != std::string::npos);
+  REQUIRE (rc.find (level) != std::string::npos);
 }
 
 TEST_CASE ("logger.error logs at error log level")
 {
   std::string rc;
-  Logger logger (std::make_unique<Test::Sink> (rc));
+  Logger logger (std::make_unique<test::Sink> (rc));
   
   const std::string message = "message";
   logger.error (message);
 
   const std::string level = levelToString (Level::ERROR);
-  std::string result = rc;
-  REQUIRE (result.find (level) != std::string::npos);
+  REQUIRE (rc.find (level) != std::string::npos);
 }
 
 TEST_CASE ("logger.fatal logs at fatal log level")
 {
   std::string rc;
-  Logger logger (std::make_unique<Test::Sink> (rc));
+  Logger logger (std::make_unique<test::Sink> (rc));
   
   const std::string message = "message";
   logger.fatal (message);
 
   const std::string level = levelToString (Level::FATAL);
-  std::string result = rc;
-  REQUIRE (result.find (level) != std::string::npos);
+  REQUIRE (rc.find (level) != std::string::npos);
 }
 
 TEST_CASE ("doesn't log below threshold")
 {
   std::string rc;
-  Logger logger (std::make_unique<Test::Sink> (rc));
+  Logger logger (std::make_unique<test::Sink> (rc));
   
   const std::string previousMessage = "previous message";
   logger.log (Level::ERROR, previousMessage);
@@ -179,7 +173,7 @@ TEST_CASE ("doesn't log below threshold")
 TEST_CASE ("does_log_above_threshold")
 {
   std::string rc;
-  Logger logger (std::make_unique<Test::Sink> (rc));
+  Logger logger (std::make_unique<test::Sink> (rc));
   
   const std::string previousMessage = "previous message";
   logger.log (Level::ERROR, previousMessage);
@@ -195,10 +189,8 @@ TEST_CASE ("does_log_above_threshold")
 
 TEST_CASE ("Logging to a thread safe sink")
 {
-  using namespace Toolbox::Sink;
-
   std::string rc;
-  Logger logger (make_unique_thread_safe<Test::Sink> (rc));
+  Logger logger (toolbox::sink::make_unique_thread_safe<test::Sink> (rc));
   std::string message = "test";
   logger.info (message);
 

--- a/C++/libs/Log/test/src/Logger.cpp
+++ b/C++/libs/Log/test/src/Logger.cpp
@@ -189,7 +189,7 @@ TEST_CASE ("does_log_above_threshold")
 
 TEST_CASE ("Logging to a thread safe sink")
 {
-  using toolbox::sink;
+  using toolbox::sink::make_unique_thread_safe;
 
   std::string rc;
   Logger logger(make_unique_thread_safe<test::Sink>(rc));

--- a/C++/libs/Log/test/src/Logger.cpp
+++ b/C++/libs/Log/test/src/Logger.cpp
@@ -10,189 +10,191 @@ using namespace toolbox::log;
 
 const std::string createMessage (const Level & level, const std::string & message)
 {
-  return levelToString (level) + ": " + message + "\n";
+  return levelToString(level) + ": " + message + "\n";
 }
 
 TEST_CASE ("get and set default log level")
 {
   std::string rc;
-  Logger logger (std::make_unique<test::Sink> (rc));
+  Logger logger(std::make_unique<test::Sink>(rc));
  
   Level level = Level::DEBUG;
-  logger.setDefault (level);
+  logger.setDefault(level);
 
-  REQUIRE (logger.getDefault () == level);
+  REQUIRE(logger.getDefault() == level);
 }
 
 TEST_CASE ("get and set threshold log level")
 {
   std::string rc;
-  Logger logger (std::make_unique<test::Sink> (rc));
+  Logger logger(std::make_unique<test::Sink>(rc));
   
   Level level = Level::DEBUG;
-  logger.setThreshold (level);
+  logger.setThreshold(level);
 
-  REQUIRE (logger.getThreshold () == level);
+  REQUIRE(logger.getThreshold() == level);
 }
 
 TEST_CASE ("log with default level")
 {
   std::string rc;
-  Logger logger (std::make_unique<test::Sink> (rc));
+  Logger logger(std::make_unique<test::Sink>(rc));
   
   const std::string message = "message";
-  logger.log (message);
+  logger.log(message);
 
-  REQUIRE (rc == createMessage (logger.getDefault (), message));
+  REQUIRE(rc == createMessage(logger.getDefault(), message));
 }
 
 TEST_CASE ("log with specific level")
 {
   std::string rc;
-  Logger logger (std::make_unique<test::Sink> (rc));
+  Logger logger(std::make_unique<test::Sink>(rc));
   
   const std::string message = "message";
   Level level = Level::INFO;
-  logger.log (level, message);
+  logger.log(level, message);
 
-  REQUIRE (rc == createMessage (level, message));
+  REQUIRE(rc == createMessage(level, message));
 }
 
 TEST_CASE ("can log strings")
 {
   std::string rc;
-  Logger logger (std::make_unique<test::Sink> (rc));
+  Logger logger(std::make_unique<test::Sink>(rc));
 
   const std::string message = "message";
-  logger.log (message);
+  logger.log(message);
 
-  REQUIRE (rc == createMessage (logger.getDefault (), message));
+  REQUIRE(rc == createMessage(logger.getDefault(), message));
 }
 
 TEST_CASE ("can log ConvertibleTo<string> objects")
 {
   std::string rc;
-  Logger logger (std::make_unique<test::Sink> (rc));
+  Logger logger(std::make_unique<test::Sink>(rc));
 
   const std::string message = "message";
-  const test::Message testMessage (message);
-  logger.log (testMessage);
+  const test::Message testMessage(message);
+  logger.log(testMessage);
 
-  REQUIRE (rc == createMessage (logger.getDefault (), message));
+  REQUIRE(rc == createMessage(logger.getDefault(), message));
 }
 
 TEST_CASE ("logger.trace logs at trace log level")
 {
   std::string rc;
-  Logger logger (std::make_unique<test::Sink> (rc));
+  Logger logger(std::make_unique<test::Sink>(rc));
  
   const std::string message = "message";
-  logger.trace (message);
+  logger.trace(message);
 
-  const std::string level = levelToString (Level::TRACE);
-  REQUIRE (rc.find (level) != std::string::npos);
+  const std::string level = levelToString(Level::TRACE);
+  REQUIRE(rc.find(level) != std::string::npos);
 }
 
 TEST_CASE ("logger.debug logs at debug log level")
 {
   std::string rc;
-  Logger logger (std::make_unique<test::Sink> (rc));
+  Logger logger(std::make_unique<test::Sink>(rc));
   
   const std::string message = "message";
-  logger.debug (message);
+  logger.debug(message);
 
-  const std::string level = levelToString (Level::DEBUG);
-  REQUIRE (rc.find (level) != std::string::npos);
+  const std::string level = levelToString(Level::DEBUG);
+  REQUIRE(rc.find(level) != std::string::npos);
 }
 
 TEST_CASE ("logger.info logs at info log level")
 {
   std::string rc;
-  Logger logger (std::make_unique<test::Sink> (rc));
+  Logger logger(std::make_unique<test::Sink>(rc));
   
   const std::string message = "message";
-  logger.info (message);
+  logger.info(message);
 
-  const std::string level = levelToString (Level::INFO);
-  REQUIRE (rc.find (level) != std::string::npos);
+  const std::string level = levelToString(Level::INFO);
+  REQUIRE(rc.find(level) != std::string::npos);
 }
 
 TEST_CASE ("logger.warning logs at warning log level")
 {
   std::string rc;
-  Logger logger (std::make_unique<test::Sink> (rc));
+  Logger logger(std::make_unique<test::Sink>(rc));
   
   const std::string message = "message";
   logger.warning (message);
 
-  const std::string level = levelToString (Level::WARNING);
-  REQUIRE (rc.find (level) != std::string::npos);
+  const std::string level = levelToString(Level::WARNING);
+  REQUIRE(rc.find(level) != std::string::npos);
 }
 
 TEST_CASE ("logger.error logs at error log level")
 {
   std::string rc;
-  Logger logger (std::make_unique<test::Sink> (rc));
+  Logger logger(std::make_unique<test::Sink>(rc));
   
   const std::string message = "message";
-  logger.error (message);
+  logger.error(message);
 
-  const std::string level = levelToString (Level::ERROR);
-  REQUIRE (rc.find (level) != std::string::npos);
+  const std::string level = levelToString(Level::ERROR);
+  REQUIRE(rc.find(level) != std::string::npos);
 }
 
 TEST_CASE ("logger.fatal logs at fatal log level")
 {
   std::string rc;
-  Logger logger (std::make_unique<test::Sink> (rc));
+  Logger logger(std::make_unique<test::Sink> (rc));
   
   const std::string message = "message";
-  logger.fatal (message);
+  logger.fatal(message);
 
-  const std::string level = levelToString (Level::FATAL);
-  REQUIRE (rc.find (level) != std::string::npos);
+  const std::string level = levelToString(Level::FATAL);
+  REQUIRE(rc.find(level) != std::string::npos);
 }
 
 TEST_CASE ("doesn't log below threshold")
 {
   std::string rc;
-  Logger logger (std::make_unique<test::Sink> (rc));
+  Logger logger(std::make_unique<test::Sink>(rc));
   
   const std::string previousMessage = "previous message";
-  logger.log (Level::ERROR, previousMessage);
+  logger.log(Level::ERROR, previousMessage);
   
   logger.setThreshold (Level::INFO);
 
   const std::string newMessage = "new message";
   Level level = Level::TRACE;
-  logger.log (level, newMessage);
+  logger.log(level, newMessage);
 
-  REQUIRE (rc != createMessage (level, newMessage));
+  REQUIRE(rc != createMessage(level, newMessage));
 }
 
 TEST_CASE ("does_log_above_threshold")
 {
   std::string rc;
-  Logger logger (std::make_unique<test::Sink> (rc));
+  Logger logger(std::make_unique<test::Sink>(rc));
   
   const std::string previousMessage = "previous message";
-  logger.log (Level::ERROR, previousMessage);
+  logger.log(Level::ERROR, previousMessage);
   
-  logger.setThreshold (Level::INFO);
+  logger.setThreshold(Level::INFO);
 
   const std::string newMessage = "new message";
   Level level = Level::INFO;
-  logger.log (level, newMessage);
+  logger.log(level, newMessage);
 
-  REQUIRE (rc == createMessage (level, newMessage));
+  REQUIRE(rc == createMessage(level, newMessage));
 }
 
 TEST_CASE ("Logging to a thread safe sink")
 {
-  std::string rc;
-  Logger logger (toolbox::sink::make_unique_thread_safe<test::Sink> (rc));
-  std::string message = "test";
-  logger.info (message);
+  using toolbox::sink;
 
-  REQUIRE (rc == createMessage (Level::INFO, message));
+  std::string rc;
+  Logger logger(make_unique_thread_safe<test::Sink>(rc));
+  std::string message = "test";
+  logger.info(message);
+
+  REQUIRE(rc == createMessage(Level::INFO, message));
 }

--- a/C++/libs/Log/test/src/TestMessage.cpp
+++ b/C++/libs/Log/test/src/TestMessage.cpp
@@ -1,12 +1,17 @@
 #include "TestMessage.h"
 
- TestMessage::TestMessage (const std::string & message)
+namespace toolbox::log::test
+{
+
+ Message::Message (const std::string & message)
  : _message (message)
  {
 
  }
 
-TestMessage::operator std::string (void) const
+ Message::operator std::string (void) const
 {
   return _message;
 }
+
+} // namespace toolbox::log::test

--- a/C++/libs/Log/test/src/TestMessage.cpp
+++ b/C++/libs/Log/test/src/TestMessage.cpp
@@ -4,7 +4,7 @@ namespace toolbox::log::test
 {
 
  Message::Message (const std::string & message)
- : _message (message)
+ : _message(message)
  {
 
  }

--- a/C++/libs/Log/test/src/TestMessage.h
+++ b/C++/libs/Log/test/src/TestMessage.h
@@ -1,16 +1,17 @@
-#ifndef _TEST_MESSAGE_H_
-#define _TEST_MESSAGE_H_
+#pragma once
 
 #include <Toolbox/Conversion/ConvertibleTo.h>
-
 #include <string>
 
-using Toolbox::Log::Conversion::ConvertibleTo;
+using toolbox::conversion::ConvertibleTo;
 
-class TestMessage : public ConvertibleTo<std::string>
+namespace toolbox::log::test
+{
+
+class Message : public ConvertibleTo<std::string>
 {
 public:
-  explicit TestMessage (const std::string & message);
+  explicit Message (const std::string & message);
 
   operator std::string (void) const override;
 
@@ -18,4 +19,4 @@ private:
   const std::string _message;
 };
 
-#endif // _TEST_MESSAGE_H_
+} // namespace toolbox::log::test

--- a/C++/libs/Log/test/src/TestSink.cpp
+++ b/C++/libs/Log/test/src/TestSink.cpp
@@ -1,6 +1,6 @@
 #include "TestSink.h"
 
-namespace Toolbox::Log::Test
+namespace toolbox::log::test
 {
 
 Sink::Sink (std::string & resource)
@@ -14,4 +14,4 @@ void Sink::output (const std::string & output)
   _resource = output;
 }
 
-} // namespace Toolbox::Log::Test
+} // namespace toolbox::log::test

--- a/C++/libs/Log/test/src/TestSink.cpp
+++ b/C++/libs/Log/test/src/TestSink.cpp
@@ -4,7 +4,7 @@ namespace toolbox::log::test
 {
 
 Sink::Sink (std::string & resource)
-: _resource (resource)
+: _resource(resource)
 {
 
 }

--- a/C++/libs/Log/test/src/TestSink.h
+++ b/C++/libs/Log/test/src/TestSink.h
@@ -1,13 +1,11 @@
-#ifndef _TEST_SINK_H_
-#define _TEST_SINK_H_
+#pragma once
 
 #include <Toolbox/Sink/BasicSink.h>
-
 #include <string>
 
-using Toolbox::Sink::BasicSink;
+using toolbox::sink::BasicSink;
 
-namespace Toolbox::Log::Test
+namespace toolbox::log::test
 {
 
 class Sink : public BasicSink<std::string>
@@ -21,6 +19,4 @@ private:
   std::string & _resource;
 };
 
-} // namespace Toolbox::Log::Test
-
-#endif // _TEST_SINK_H_
+} // namespace toolbox::log::test

--- a/C++/libs/Option/test/src/Option.cpp
+++ b/C++/libs/Option/test/src/Option.cpp
@@ -2,7 +2,7 @@
 #include <Toolbox/Option/Option.h>
 #include "TestWidget.h"
 
-TEST_CASE("create a Some")
+TEST_CASE ("create a Some")
 {
   using namespace toolbox;
   using toolbox::option::test::Widget;
@@ -21,7 +21,7 @@ TEST_CASE("create a Some")
   REQUIRE(isSome);
 }
 
-TEST_CASE("Create a Some from a new instance")
+TEST_CASE ("Create a Some from a new instance")
 {
   using namespace toolbox;
   using toolbox::option::test::Widget;
@@ -40,7 +40,7 @@ TEST_CASE("Create a Some from a new instance")
   REQUIRE(isSome);
 }
 
-TEST_CASE("Create a None from a nullptr")
+TEST_CASE ("Create a None from a nullptr")
 {
   using namespace toolbox;
   using toolbox::option::test::Widget;
@@ -59,7 +59,7 @@ TEST_CASE("Create a None from a nullptr")
   REQUIRE(isNone);
 }
 
-TEST_CASE("Map a widget with index 5 to index 10")
+TEST_CASE ("Map a widget with index 5 to index 10")
 {
   using namespace toolbox;
   using toolbox::option::test::Widget;
@@ -95,7 +95,7 @@ TEST_CASE("Map a widget with index 5 to index 10")
   REQUIRE(newWidgetIndex == 10);
 }
 
-TEST_CASE("Filter an option by index") 
+TEST_CASE ("Filter an option by index") 
 {
   using namespace toolbox;
   using toolbox::option::test::Widget;

--- a/C++/libs/Option/test/src/Option.cpp
+++ b/C++/libs/Option/test/src/Option.cpp
@@ -4,11 +4,11 @@
 
 TEST_CASE("create a Some")
 {
-  using namespace Toolbox;
-  using Toolbox::Option::Test::Widget;
+  using namespace toolbox;
+  using toolbox::option::test::Widget;
 
   // create a widget with index 10
-  auto widgetOption = Option::Some<Widget>(10);
+  auto widgetOption = option::Some<Widget>(10);
 
   int x = 0;
   widgetOption.ifPresent([&x](const Widget& widget) {
@@ -23,12 +23,12 @@ TEST_CASE("create a Some")
 
 TEST_CASE("Create a Some from a new instance")
 {
-  using namespace Toolbox;
-  using Toolbox::Option::Test::Widget;
+  using namespace toolbox;
+  using toolbox::option::test::Widget;
 
   auto pWidget = new Widget{5};
   // widgetOption now owns pWidget
-  auto widgetOption = Option::Option(pWidget);
+  auto widgetOption = option::Option(pWidget);
 
   int x = 0;
   widgetOption.ifPresent([&x](const Widget& widget) {
@@ -42,11 +42,11 @@ TEST_CASE("Create a Some from a new instance")
 
 TEST_CASE("Create a None from a nullptr")
 {
-  using namespace Toolbox;
-  using Toolbox::Option::Test::Widget;
+  using namespace toolbox;
+  using toolbox::option::test::Widget;
 
   Widget* pWidget = nullptr;
-  auto widgetOption = Option::Option(pWidget);
+  auto widgetOption = option::Option(pWidget);
 
   int x = 0;
   widgetOption.ifPresent([&x](const Widget& widget) {
@@ -61,12 +61,12 @@ TEST_CASE("Create a None from a nullptr")
 
 TEST_CASE("Map a widget with index 5 to index 10")
 {
-  using namespace Toolbox;
-  using Toolbox::Option::Test::Widget;
+  using namespace toolbox;
+  using toolbox::option::test::Widget;
 
   // create a widget with index 5
   int widgetIndex = 5;
-  auto widgetOption = Option::Some<Widget>(widgetIndex);
+  auto widgetOption = option::Some<Widget>(widgetIndex);
   // reset this variable for later
   widgetIndex = 0;
 
@@ -97,12 +97,12 @@ TEST_CASE("Map a widget with index 5 to index 10")
 
 TEST_CASE("Filter an option by index") 
 {
-  using namespace Toolbox;
-  using Toolbox::Option::Test::Widget;
+  using namespace toolbox;
+  using toolbox::option::test::Widget;
 
   // create a widget with index 5
   int widgetIndex = 5;
-  auto widgetOption = Option::Some<Widget>(widgetIndex);
+  auto widgetOption = option::Some<Widget>(widgetIndex);
 
   // filter by a condition that retains the value, e.g. index 5 is greater than 0
   widgetOption = widgetOption.filter([](const Widget& widget) {

--- a/C++/libs/Option/test/src/TestWidget.cpp
+++ b/C++/libs/Option/test/src/TestWidget.cpp
@@ -1,22 +1,21 @@
 #include "TestWidget.h"
 
-namespace Toolbox {
-namespace Option {
-namespace Test {
+namespace toolbox::option::test
+{
   
-    Widget::Widget(int index) : m_index(index) 
-    { 
-    }
+Widget::Widget(int index)
+: _index(index) 
+{
 
-    const int& Widget::getIndex(void) const {
-      return m_index;
-    }
+}
 
-    void Widget::setIndex(const int& index) {
-      m_index = index;
-    } 
-  
-} // Test
-} // Option
-} // Toolbox
+const int& Widget::getIndex(void) const {
+  return _index;
+}
+
+void Widget::setIndex(const int& index) {
+  _index = index;
+}
+
+} // namespace toolbox::option::test
   

--- a/C++/libs/Option/test/src/TestWidget.cpp
+++ b/C++/libs/Option/test/src/TestWidget.cpp
@@ -3,17 +3,19 @@
 namespace toolbox::option::test
 {
   
-Widget::Widget(int index)
+Widget::Widget (int index)
 : _index(index) 
 {
 
 }
 
-const int& Widget::getIndex(void) const {
+const int & Widget::getIndex (void) const
+{
   return _index;
 }
 
-void Widget::setIndex(const int& index) {
+void Widget::setIndex (const int & index)
+{
   _index = index;
 }
 

--- a/C++/libs/Option/test/src/TestWidget.h
+++ b/C++/libs/Option/test/src/TestWidget.h
@@ -3,14 +3,14 @@
 namespace toolbox::option::test
 {
 
-class Widget {
-
+class Widget
+{
 public:
-  Widget(void) = default;
-  Widget(int index);
+  Widget (void) = default;
+  Widget (int index);
 
-  const int& getIndex(void) const;
-  void setIndex(const int& index);
+  const int & getIndex (void) const;
+  void setIndex (const int & index);
 
 private:
   int _index;

--- a/C++/libs/Option/test/src/TestWidget.h
+++ b/C++/libs/Option/test/src/TestWidget.h
@@ -1,9 +1,7 @@
-#ifndef _OPTION_TEST_WIDGET_H_
-#define _OPTION_TEST_WIDGET_H_
+#pragma once
 
-namespace Toolbox {
-namespace Option {
-namespace Test {
+namespace toolbox::option::test
+{
 
 class Widget {
 
@@ -15,15 +13,7 @@ public:
   void setIndex(const int& index);
 
 private:
-  int m_index;
-
+  int _index;
 };
 
-} // Test
-} // Option
-} // Toolbox
-
-
-#endif // _OPTION_TEST_WIDGET_H_
- 
-
+} // namespace toolbox::option::test

--- a/C++/libs/Sink/src/ConsoleSink.cpp
+++ b/C++/libs/Sink/src/ConsoleSink.cpp
@@ -1,8 +1,7 @@
 #include <Toolbox/Sink/ConsoleSink.h>
-
 #include <iostream>
 
-namespace Toolbox::Sink
+namespace toolbox::sink
 {
 
 void ConsoleSink::output (const std::string & output)
@@ -10,4 +9,4 @@ void ConsoleSink::output (const std::string & output)
   std::cout << output;
 }
 
-} // namespace Toolbox::Sink
+} // namespace toolbox::sink

--- a/C++/libs/Sink/test/src/BasicSink.cpp
+++ b/C++/libs/Sink/test/src/BasicSink.cpp
@@ -6,9 +6,9 @@ using namespace toolbox::sink;
 TEST_CASE ("stream operator accepts the message")
 {
   std::string rc;
-  test::Sink sink (rc);
+  test::Sink sink(rc);
   const std::string message = "test";
   sink << message;
 
-  REQUIRE (rc == message);
+  REQUIRE(rc == message);
 }

--- a/C++/libs/Sink/test/src/BasicSink.cpp
+++ b/C++/libs/Sink/test/src/BasicSink.cpp
@@ -1,13 +1,12 @@
 #include <Toolbox/catch.hpp>
-
 #include "TestSink.h"
 
-using namespace Toolbox::Sink;
+using namespace toolbox::sink;
 
 TEST_CASE ("stream operator accepts the message")
 {
   std::string rc;
-  Test::Sink sink (rc);
+  test::Sink sink (rc);
   const std::string message = "test";
   sink << message;
 

--- a/C++/libs/Sink/test/src/TestSink.cpp
+++ b/C++/libs/Sink/test/src/TestSink.cpp
@@ -1,6 +1,6 @@
 #include "TestSink.h"
 
-namespace Toolbox::Sink::Test
+namespace toolbox::sink::test
 {
 
 Sink::Sink (std::string & resource)
@@ -25,4 +25,4 @@ void SafeSink::output (const std::string & output)
   _resource = output;
 }
 
-} // namespace Toolbox::Sink::Test
+} // namespace toolbox::sink::test

--- a/C++/libs/Sink/test/src/TestSink.cpp
+++ b/C++/libs/Sink/test/src/TestSink.cpp
@@ -4,7 +4,7 @@ namespace toolbox::sink::test
 {
 
 Sink::Sink (std::string & resource)
-: _resource (resource)
+: _resource(resource)
 {
 
 }
@@ -15,7 +15,7 @@ void Sink::output (const std::string & output)
 }
 
 SafeSink::SafeSink (std::string & resource)
-: _resource (resource)
+: _resource(resource)
 {
 
 }

--- a/C++/libs/Sink/test/src/TestSink.h
+++ b/C++/libs/Sink/test/src/TestSink.h
@@ -1,15 +1,12 @@
-#ifndef _TEST_SINK_H_
-#define _TEST_SINK_H_
+#pragma once
 
 #include <Toolbox/Sink/BasicSink.h>
 #include <Toolbox/Sink/ThreadSafeSink.h>
-
 #include <string>
-#include <sstream>
 
-using Toolbox::Sink::BasicSink;
+using toolbox::sink::BasicSink;
 
-namespace Toolbox::Sink::Test
+namespace toolbox::sink::test
 {
 
 class Sink : public BasicSink<std::string>
@@ -36,6 +33,4 @@ private:
   std::string & _resource;
 };
 
-} // namespace Toolbox::Sink::Test
-
-#endif // _TEST_SINK_H_
+} // namespace toolbox::sink::test

--- a/C++/libs/Sink/test/src/ThreadSafeSink.cpp
+++ b/C++/libs/Sink/test/src/ThreadSafeSink.cpp
@@ -1,17 +1,14 @@
 #include <Toolbox/catch.hpp>
-
 #include "TestSink.h"
 #include <Toolbox/Sink/ThreadSafeProxySink.h>
-#include <thread>
-#include <sstream>
 
-using namespace Toolbox::Sink;
+using namespace toolbox::sink;
 
 TEST_CASE ("ThreadSafeProxySink with lvalue Sink")
 {
   std::string rc;
-  Test::Sink sink (rc);
-  ThreadSafeProxySink<Test::Sink> proxySink (std::move (sink));
+  test::Sink sink (rc);
+  ThreadSafeProxySink<test::Sink> proxySink (std::move (sink));
   std::string message = "test";
   proxySink << message;
   
@@ -21,7 +18,7 @@ TEST_CASE ("ThreadSafeProxySink with lvalue Sink")
 TEST_CASE ("ThreadSafeProxySink with rvalue Sink")
 {
   std::string rc;
-  ThreadSafeProxySink<Test::Sink> proxySink (Test::Sink {rc});
+  ThreadSafeProxySink<test::Sink> proxySink (test::Sink {rc});
   std::string message = "test";
   proxySink << message;
   
@@ -31,7 +28,7 @@ TEST_CASE ("ThreadSafeProxySink with rvalue Sink")
 TEST_CASE ("Instantiate ThreadSafeProxySink using make_thread_safe")
 {
   std::string rc;
-  auto proxySink = make_thread_safe<Test::Sink>(rc);
+  auto proxySink = make_thread_safe<test::Sink>(rc);
   std::string message = "test";
   proxySink << message;
 
@@ -41,7 +38,7 @@ TEST_CASE ("Instantiate ThreadSafeProxySink using make_thread_safe")
 TEST_CASE ("Instantiate a unique_ptr<ThreadSafeProxySink> using make_unique_thread_safe")
 {
   std::string rc;
-  auto proxySink = make_unique_thread_safe<Test::Sink>(rc);
+  auto proxySink = make_unique_thread_safe<test::Sink>(rc);
   std::string message = "test";
   (*proxySink) << message;
 
@@ -51,7 +48,7 @@ TEST_CASE ("Instantiate a unique_ptr<ThreadSafeProxySink> using make_unique_thre
 TEST_CASE ("ThreadSafeSink")
 {
   std::string rc;
-  Test::SafeSink safeSink (rc);
+  test::SafeSink safeSink (rc);
   std::string message = "test";
   safeSink << message;
 

--- a/C++/libs/Sink/test/src/ThreadSafeSink.cpp
+++ b/C++/libs/Sink/test/src/ThreadSafeSink.cpp
@@ -7,22 +7,22 @@ using namespace toolbox::sink;
 TEST_CASE ("ThreadSafeProxySink with lvalue Sink")
 {
   std::string rc;
-  test::Sink sink (rc);
-  ThreadSafeProxySink<test::Sink> proxySink (std::move (sink));
+  test::Sink sink(rc);
+  ThreadSafeProxySink<test::Sink> proxySink(std::move(sink));
   std::string message = "test";
   proxySink << message;
   
-  REQUIRE (rc == message);
+  REQUIRE(rc == message);
 }
 
 TEST_CASE ("ThreadSafeProxySink with rvalue Sink")
 {
   std::string rc;
-  ThreadSafeProxySink<test::Sink> proxySink (test::Sink {rc});
+  ThreadSafeProxySink<test::Sink> proxySink(test::Sink{rc});
   std::string message = "test";
   proxySink << message;
   
-  REQUIRE (rc == message);
+  REQUIRE(rc == message);
 }
 
 TEST_CASE ("Instantiate ThreadSafeProxySink using make_thread_safe")
@@ -32,7 +32,7 @@ TEST_CASE ("Instantiate ThreadSafeProxySink using make_thread_safe")
   std::string message = "test";
   proxySink << message;
 
-  REQUIRE (rc == message);
+  REQUIRE(rc == message);
 }
 
 TEST_CASE ("Instantiate a unique_ptr<ThreadSafeProxySink> using make_unique_thread_safe")
@@ -42,15 +42,15 @@ TEST_CASE ("Instantiate a unique_ptr<ThreadSafeProxySink> using make_unique_thre
   std::string message = "test";
   (*proxySink) << message;
 
-  REQUIRE (rc == message);
+  REQUIRE(rc == message);
 }
 
 TEST_CASE ("ThreadSafeSink")
 {
   std::string rc;
-  test::SafeSink safeSink (rc);
+  test::SafeSink safeSink(rc);
   std::string message = "test";
   safeSink << message;
 
-  REQUIRE (rc == message);
+  REQUIRE(rc == message);
 }

--- a/C++/libs/Time/src/Time.cpp
+++ b/C++/libs/Time/src/Time.cpp
@@ -2,9 +2,11 @@
 #include <ctime>
 #include <chrono>
 
-namespace Toolbox::Time
+namespace toolbox::time
 {
-namespace {
+
+namespace
+{
 
 const std::string removeTrailingNewline (const std::string & text)
 {
@@ -31,4 +33,4 @@ const std::string getCurrentTime (void)
   return removeTrailingNewline (std::string(timestamp));
 }
 
-} // namespace Toolbox::Time
+} // namespace toolbox::time

--- a/C++/libs/Time/src/Time.cpp
+++ b/C++/libs/Time/src/Time.cpp
@@ -10,14 +10,14 @@ namespace
 
 const std::string removeTrailingNewline (const std::string & text)
 {
-  return text.substr (0, text.length () - 1);
+  return text.substr(0, text.length() - 1);
 }
 
 } // end anonymous namespace 
 
 const std::string getCurrentTime (void) 
 {
-  std::time_t now = std::chrono::system_clock::to_time_t (std::chrono::system_clock::now ());
+  std::time_t now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now ());
   std::tm localNow;
 #if (_MSC_VER > 1300)
   // localtime_s is not in namespace std on vc++ libraries for some reason
@@ -30,7 +30,7 @@ const std::string getCurrentTime (void)
   char format[] = "%c";
   char timestamp[dateSize];
   std::strftime(timestamp, dateSize, format, &localNow);
-  return removeTrailingNewline (std::string(timestamp));
+  return removeTrailingNewline(std::string(timestamp));
 }
 
 } // namespace toolbox::time


### PR DESCRIPTION
### Changes proposed within this pull request:
- Namespaces have been changed to snake_case.
- #ifndef guards have been migrated to #pragma once
- Function calls, and initializer list parenthesis have been updated to be next to their function name.
  - e.g. foo(t).  or _member(value).
- Function definitions/declarations will keep the space next to their function name.
  - e.g. void foo (T t).
